### PR TITLE
Enable closures with model arguments.

### DIFF
--- a/src/Torann/LaravelRepository/Repositories/AbstractCacheDecorator.php
+++ b/src/Torann/LaravelRepository/Repositories/AbstractCacheDecorator.php
@@ -239,6 +239,12 @@ abstract class AbstractCacheDecorator implements RepositoryInterface
      */
     public function getCacheKey($method, $args = null)
     {
+        foreach($args as &$a) {
+            if ($a instanceof Model) {
+                $a = get_class($a).'|'.$a->getKey();
+            }
+        }
+        
         $args = serialize($args)
             . serialize($this->repo->getScopeQuery())
             . serialize($this->repo->getWith());


### PR DESCRIPTION
An Exception is thrown if you use the Model typehint / type as an argument(s) in your repository methods, a pretty common practice. `Serialization of 'Closure' is not allowed` There may be a more clever way to support more types of objects, but this was fast, easy and worked for my purposes.
