### PR TITLE
Set custom time in getCache method

### DIFF
--- a/src/Torann/LaravelRepository/Repositories/AbstractCacheDecorator.php
+++ b/src/Torann/LaravelRepository/Repositories/AbstractCacheDecorator.php
@@ -295,7 +295,7 @@ abstract class AbstractCacheDecorator implements RepositoryInterface
                 : $this->cacheMinutes;
         }
 
-        return $this->cacheMinutes;
+        return is_null($time) ? $this->cacheMinutes : $time;
     }
 
     /**


### PR DESCRIPTION
Now, the getCacheExpiresTime method can set a custom time passed by getCache. 
Before, this method returns $this->cacheMinutes allways.